### PR TITLE
fixed random point for 1d space

### DIFF
--- a/thesimulator/util/spaces.py
+++ b/thesimulator/util/spaces.py
@@ -108,6 +108,9 @@ class Euclidean1D(Euclidean):
     def d(self, u, v):
         return abs(v - u)
 
+    def random_point(self):
+        return random.uniform(*self.coord_range[0])
+
 
 class Euclidean2D(Euclidean):
     def __init__(


### PR DESCRIPTION
* [x] random point bug fixed for 1D space (should return float, not ndarray)

resolves #40