### PR TITLE
Setup basic version of C++ library

### DIFF
--- a/ridepy/cpp/.gitignore
+++ b/ridepy/cpp/.gitignore
@@ -1,0 +1,75 @@
+# This file is used to ignore files which are generated
+# ----------------------------------------------------------------------------
+
+*~
+*.autosave
+*.a
+*.core
+*.moc
+*.o
+*.obj
+*.orig
+*.rej
+*.so
+*.so.*
+*_pch.h.cpp
+*_resource.rc
+*.qm
+.#*
+*.*#
+core
+!core/
+tags
+.DS_Store
+.directory
+*.debug
+Makefile*
+*.prl
+*.app
+moc_*.cpp
+ui_*.h
+qrc_*.cpp
+Thumbs.db
+*.res
+*.rc
+/.qmake.cache
+/.qmake.stash
+
+# qtcreator generated files
+*.user*
+
+# xemacs temporary files
+*.flc
+
+# Vim temporary files
+.*.swp
+
+# Visual Studio generated files
+*.ib_pdb_index
+*.idb
+*.ilk
+*.pdb
+*.sln
+*.suo
+*.vcproj
+*vcproj.*.*.user
+*.ncb
+*.sdf
+*.opensdf
+*.vcxproj
+*vcxproj.*
+
+# MinGW generated files
+*.Debug
+*.Release
+
+# Python byte code
+*.pyc
+
+# Binaries
+# --------
+*.dll
+*.exe
+
+# build directories
+build/

--- a/ridepy/cpp/CMakeLists.txt
+++ b/ridepy/cpp/CMakeLists.txt
@@ -1,0 +1,35 @@
+# In this subdirectory, a pure C++ version of RidePy can be build by running the CMake script in this file.
+# it outputs a linkable C++ library  *libRidePy.a* and an executable *ridepy-cpp-test* to run some tests
+cmake_minimum_required(VERSION 3.5)
+
+project(ridepy-cpp LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# build library
+file(GLOB RIDEPY_FILES
+    ridepy/*.h
+    ridepy.dox
+)
+add_library(RidePy
+    ${RIDEPY_FILES}
+    # TransportSpace
+    ../util/spaces_cython/ctransport_space.h
+    ../util/spaces_cython/cspaces.h
+    ../util/spaces_cython/cspaces.cxx
+    # VehicleState
+    ../vehicle_state_cython/cvehicle_state.h
+    # DataStructures
+    ../data_structures_cython/cdata_structures.h
+    # Dispatchers
+    ../util/dispatchers_cython/cdispatchers.h
+    ../util/dispatchers_cython/cdispatchers_utils.h
+)
+
+# ensure, that header files can be included when linking this library from other projects
+target_include_directories(RidePy PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
+# build test executable
+add_executable(RidePy-cpp-test main.cxx)
+target_link_libraries(RidePy-cpp-test RidePy)

--- a/ridepy/cpp/main.cxx
+++ b/ridepy/cpp/main.cxx
@@ -1,0 +1,10 @@
+#include "ridepy/spaces.h"
+#include <iostream>
+
+using namespace ridepy;
+
+int main() {
+
+  std::cout << "Hello from RidePy!" << std::endl;
+  return 0;
+}

--- a/ridepy/cpp/ridepy.dox
+++ b/ridepy/cpp/ridepy.dox
@@ -1,0 +1,20 @@
+/*!
+ * \defgroup RidePy
+ * \brief The C++ interface of the RidePy package.
+ *
+ * This library can be included in other C++ projects using CMake:
+ * Assuming, the root directory of the RidePy repository is stored in \p RIDEPY_PATH, then it remains to add
+ * \code
+ * add_subdirectory(${RIDEPY_PATH}/ridepy/cpp)
+ * \endcode
+ * to your \p CMakeLists.txt. Then, RidePy headers can be included via
+ * \code
+ * #include "ridepy/*.h"
+ * \endcode
+ */
+
+/*!
+ * \namespace ridepy
+ * \ingroup RidePy
+ * \brief The namespace that contains all specific types of the RidePy package.
+ */

--- a/ridepy/cpp/ridepy/datastructures.h
+++ b/ridepy/cpp/ridepy/datastructures.h
@@ -1,0 +1,6 @@
+#ifndef RIDEPY_CPP_DATASTRUCTURES_H
+#define RIDEPY_CPP_DATASTRUCTURES_H
+
+#include "../../data_structures_cython/cdata_structures.h"
+
+#endif // RIDEPY_CPP_DATASTRUCTURES_H

--- a/ridepy/cpp/ridepy/dispatchers.h
+++ b/ridepy/cpp/ridepy/dispatchers.h
@@ -1,0 +1,6 @@
+#ifndef RIDEPY_CPP_DISPATCHERS_H
+#define RIDEPY_CPP_DISPATCHERS_H
+
+#include "../../util/dispatchers_cython/cdispatchers.h"
+
+#endif // RIDEPY_CPP_DISPATCHERS_H

--- a/ridepy/cpp/ridepy/spaces.h
+++ b/ridepy/cpp/ridepy/spaces.h
@@ -1,0 +1,6 @@
+#ifndef RIDEPY_CPP_SPACES_H
+#define RIDEPY_CPP_SPACES_H
+
+#include "../../util/spaces_cython/cspaces.h"
+
+#endif // RIDEPY_CPP_SPACES_H

--- a/ridepy/cpp/ridepy/transportspace.h
+++ b/ridepy/cpp/ridepy/transportspace.h
@@ -1,0 +1,6 @@
+#ifndef RIDEPY_CPP_TRANSPORTSPACE_H
+#define RIDEPY_CPP_TRANSPORTSPACE_H
+
+#include "../../util/spaces_cython/ctransport_space.h"
+
+#endif // RIDEPY_CPP_TRANSPORTSPACE_H

--- a/ridepy/cpp/ridepy/vehiclestate.h
+++ b/ridepy/cpp/ridepy/vehiclestate.h
@@ -1,0 +1,6 @@
+#ifndef RIDEPY_CPP_VEHICLESTATE_H
+#define RIDEPY_CPP_VEHICLESTATE_H
+
+#include "../../vehicle_state_cython/cvehicle_state.h"
+
+#endif // RIDEPY_CPP_VEHICLESTATE_H

--- a/ridepy/data_structures_cython/cdata_structures.h
+++ b/ridepy/data_structures_cython/cdata_structures.h
@@ -5,7 +5,6 @@
 #ifndef RIDEPY_CDATA_STRUCTURES_H
 #define RIDEPY_CDATA_STRUCTURES_H
 
-#include "../util/spaces_cython/cspaces.h"
 #include <cmath>
 #include <iostream>
 #include <memory>
@@ -15,7 +14,8 @@
 
 using namespace std;
 
-namespace cstuff {
+namespace ridepy {
+
 typedef pair<double, double> R2loc;
 
 template <typename Loc> class Request {
@@ -105,6 +105,6 @@ struct SingleVehicleSolution {
   double LAST_do = INFINITY;
 };
 
-} // namespace cstuff
+} // namespace ridepy
 
 #endif // RIDEPY_CDATA_STRUCTURES_H

--- a/ridepy/data_structures_cython/cdata_structures.pxd
+++ b/ridepy/data_structures_cython/cdata_structures.pxd
@@ -4,7 +4,7 @@ from libcpp.vector cimport vector
 from libcpp.pair cimport pair
 from libcpp.memory cimport shared_ptr
 
-cdef extern from "cdata_structures.h" namespace 'cstuff':
+cdef extern from "cdata_structures.h" namespace 'ridepy':
 
     ctypedef pair[double, double] R2loc
     cpdef enum class StopAction(int):

--- a/ridepy/data_structures_cython/data_structures.pxd
+++ b/ridepy/data_structures_cython/data_structures.pxd
@@ -12,7 +12,7 @@ from ridepy.data_structures_cython.cdata_structures cimport (
     R2loc
 )
 
-cdef extern from * namespace 'cstuff':
+cdef extern from * namespace 'ridepy':
     cpdef enum class StopAction(int):
         pickup=1
         dropoff=2

--- a/ridepy/util/dispatchers_cython/cdispatchers.h
+++ b/ridepy/util/dispatchers_cython/cdispatchers.h
@@ -11,7 +11,9 @@
 #include <climits>
 
 using namespace std;
-namespace cstuff {
+
+namespace ridepy {
+
 template <typename Loc>
 InsertionResult<Loc> brute_force_total_traveltime_minimizing_dispatcher(
     std::shared_ptr<TransportationRequest<Loc>> request,
@@ -400,5 +402,6 @@ public:
   }
 };
 
-} // namespace cstuff
+} // namespace ridepy
+
 #endif // RIDEPY_CDISPATCHERS_H

--- a/ridepy/util/dispatchers_cython/cdispatchers.pxd
+++ b/ridepy/util/dispatchers_cython/cdispatchers.pxd
@@ -7,7 +7,7 @@ from ridepy.data_structures_cython.cdata_structures cimport (
 from ridepy.util.spaces_cython.cspaces cimport TransportSpace, Euclidean2D
 
 
-cdef extern from "cdispatchers.h" namespace 'cstuff':
+cdef extern from "cdispatchers.h" namespace 'ridepy':
     InsertionResult[Loc] brute_force_total_traveltime_minimizing_dispatcher[Loc](
           shared_ptr[TransportationRequest[Loc]] request,
           vector[Stop[Loc]] &stoplist,

--- a/ridepy/util/dispatchers_cython/cdispatchers_utils.h
+++ b/ridepy/util/dispatchers_cython/cdispatchers_utils.h
@@ -7,7 +7,8 @@
 
 #include "../../data_structures_cython/cdata_structures.h"
 
-namespace cstuff {
+namespace ridepy {
+
 template <typename Loc>
 std::vector<Stop<Loc>> insert_request_to_stoplist_drive_first(
     std::vector<Stop<Loc>> &stoplist,
@@ -214,6 +215,7 @@ bool is_timewindow_violated_dueto_insertion(
   }
   return false;
 }
-} // namespace cstuff
+
+} // namespace ridepy
 
 #endif // RIDEPY_CDISPATCHERS_UTILS_H

--- a/ridepy/util/spaces_cython/boost_graph_space.h
+++ b/ridepy/util/spaces_cython/boost_graph_space.h
@@ -13,7 +13,8 @@
 using namespace std;
 using namespace boost;
 
-namespace cstuff {
+namespace ridepy {
+
 template <typename vertex_t>
 class GraphSpace : public TransportSpace<vertex_t> {
   typedef adjacency_list<vecS, vecS, undirectedS,
@@ -189,5 +190,7 @@ public:
     return w;
   }
 };
-} // namespace cstuff
+
+} // namespace ridepy
+
 #endif

--- a/ridepy/util/spaces_cython/cspaces.cxx
+++ b/ridepy/util/spaces_cython/cspaces.cxx
@@ -2,10 +2,10 @@
 
 using namespace std;
 
-namespace cstuff {
+namespace ridepy {
 
-Euclidean2D::Euclidean2D() : TransportSpace{} {};
-Euclidean2D::Euclidean2D(double velocity) : TransportSpace{velocity} {};
+Euclidean2D::Euclidean2D() : TransportSpace{} {}
+Euclidean2D::Euclidean2D(double velocity) : TransportSpace{velocity} {}
 
 double Euclidean2D::d(R2loc u, R2loc v) {
   return sqrt((u.first - v.first) * (u.first - v.first) +
@@ -30,8 +30,8 @@ pair<R2loc, double> Euclidean2D::interp_time(R2loc u, R2loc v,
   return this->interp_dist(u, v, dist_to_dest);
 }
 
-Manhattan2D::Manhattan2D() : TransportSpace{} {};
-Manhattan2D::Manhattan2D(double velocity) : TransportSpace{velocity} {};
+Manhattan2D::Manhattan2D() : TransportSpace{} {}
+Manhattan2D::Manhattan2D(double velocity) : TransportSpace{velocity} {}
 
 double Manhattan2D::d(R2loc u, R2loc v) {
   return std::abs(u.first - v.first) + std::abs(u.second - v.second);
@@ -54,4 +54,5 @@ pair<R2loc, double> Manhattan2D::interp_time(R2loc u, R2loc v,
   double dist_to_dest = time_to_dest * (this->velocity);
   return this->interp_dist(u, v, dist_to_dest);
 }
-} // namespace cstuff
+
+} // namespace ridepy

--- a/ridepy/util/spaces_cython/cspaces.h
+++ b/ridepy/util/spaces_cython/cspaces.h
@@ -14,9 +14,20 @@
 #include <utility> // for pair
 #include <vector>
 
+#include "ctransport_space.h"
+
 using namespace std;
 
-namespace cstuff {
+namespace ridepy {
+
+/*!
+ * \addtogroup RidePy
+ * @{
+ */
+
+/*!
+ * \brief A point in the 2D plane
+ */
 typedef pair<double, double> R2loc;
 
 std::ostream& operator<<(std::ostream& stream, R2loc const& x)
@@ -24,20 +35,10 @@ std::ostream& operator<<(std::ostream& stream, R2loc const& x)
     return stream << "(" << x.first << "," << x.second << ")" << endl;
 }
 
-template <typename Loc> class TransportSpace {
-public:
-  double velocity;
-
-  virtual double d(Loc u, Loc v) = 0;
-  virtual double t(Loc u, Loc v) = 0;
-  virtual pair<Loc, double> interp_dist(Loc u, Loc v, double dist_to_dest) = 0;
-  virtual pair<Loc, double> interp_time(Loc u, Loc v, double time_to_dest) = 0;
-
-  TransportSpace() : velocity{1} {};
-  TransportSpace(double velocity) : velocity{velocity} {};
-  virtual ~TransportSpace(){};
-};
-
+/*!
+ * \brief The Euclidean2D class allows vehicles to drive anywhere on the 2D
+ * plane.
+ */
 class Euclidean2D : public TransportSpace<R2loc> {
 public:
   double d(R2loc u, R2loc v) override;
@@ -51,6 +52,10 @@ public:
   Euclidean2D(double);
 };
 
+/*!
+ * \brief The Euclidean2D class allows vehicles to drive anywhere on the 2D
+ * plane.
+ */
 class Manhattan2D : public TransportSpace<R2loc> {
 public:
   double d(R2loc u, R2loc v) override;
@@ -64,7 +69,11 @@ public:
   Manhattan2D(double);
 };
 
-} // namespace cstuff
+/*!
+ * @}
+ */
+
+} // namespace ridepy
 
 #endif
 // RIDEPY_CSPACES_H

--- a/ridepy/util/spaces_cython/cspaces.pxd
+++ b/ridepy/util/spaces_cython/cspaces.pxd
@@ -15,7 +15,7 @@ That is, we must *not* declare Euclidean2D.d/t/... here, only in TransportSpace.
 Doing so will result in an *ambiguous overridden function* error from cython.
 """
 
-cdef extern from "cspaces.h" namespace 'cstuff':
+cdef extern from "ctransport_space.h" namespace 'ridepy':
 
     ctypedef pair[double, double] R2loc
     cdef cppclass TransportSpace[Loc]:
@@ -27,6 +27,9 @@ cdef extern from "cspaces.h" namespace 'cstuff':
         pair[Loc, double] interp_dist(Loc u, Loc v, double dist_to_dest)
         pair[Loc, double] interp_time(Loc u, Loc v, double time_to_dest)
 
+
+cdef extern from "cspaces.h" namespace 'ridepy':
+
     cdef cppclass Euclidean2D(TransportSpace[R2loc]):
         Euclidean2D()
         Euclidean2D(double)
@@ -36,7 +39,7 @@ cdef extern from "cspaces.h" namespace 'cstuff':
         Manhattan2D(double)
 
 
-cdef extern from "boost_graph_space.h" namespace 'cstuff':
+cdef extern from "boost_graph_space.h" namespace 'ridepy':
     cdef cppclass GraphSpace[Loc](TransportSpace[Loc]):
         ctypedef pair[Loc, Loc] Edge
 

--- a/ridepy/util/spaces_cython/ctransport_space.h
+++ b/ridepy/util/spaces_cython/ctransport_space.h
@@ -1,0 +1,68 @@
+#ifndef RIDEPY_TRANSPORTSPACE_H
+#define RIDEPY_TRANSPORTSPACE_H
+
+#include <utility>
+
+namespace ridepy {
+
+/*!
+ * \ingroup RidePy
+ * \brief The abtract template for a TransportSpace within which ridepooling
+ * vehicles can move \tparam Loc The coordinate that identifies a location in
+ * the transport space. This coordinate might for instance be a R2Loc to
+ * identify a location in the 2D Euclidian plane.
+ *
+ * Custom transport spaces can be defined by inheriting this interface.
+ *
+ * The type template parameter \p Loc expresses the coordinate.
+ * This might be for instance a R2Loc to identify a location by its position in
+ * the 2D Euclidian plane or the unique id of a network node.
+ */
+template <typename Loc> class TransportSpace {
+public:
+  double velocity;
+
+  /*!
+   * \brief Returns the spacial distance between the locations \p u and \p v
+   * inside this space \param u The starting point \param v The destination
+   * \return The spacial distance between the locations \p u and \p v
+   */
+  virtual double d(Loc u, Loc v) = 0;
+
+  /*!
+   * \brief Returns the time needed to travel from location \p u to \p v inside
+   * this space \param u The starting point \param v The destination \return The
+   * time needed to travel from location \p u to \p v
+   */
+  virtual double t(Loc u, Loc v) = 0;
+
+  /*!
+   * \brief Calculates the current position of a vehicle on the way from \p u to
+   * \p v at a distance \p dist_to_dest before reaching \p v \param u The origin
+   * of the ride \param v The destination of the ride \param dist_to_dest The
+   * remaining distance to reach the destination \p v \return A pair with
+   * (first) the next location that will be reached and (second) the remaining
+   * distance, until this intermediate node will be reached.
+   */
+  virtual std::pair<Loc, double> interp_dist(Loc u, Loc v,
+                                             double dist_to_dest) = 0;
+
+  /*!
+   * \brief Calculates the current position of a vehicle on the way from \p u to
+   * \p v at time \p time_to_dest before reaching \p v \param u The origin of
+   * the ride \param v The destination of the ride \param time_to_dest The
+   * remaining travel time to reach the destination \p v \return A pair with
+   * (first) the next location that will be reached and (second) the remaining
+   * travel time, until this intermediate node will be reached.
+   */
+  virtual std::pair<Loc, double> interp_time(Loc u, Loc v,
+                                             double time_to_dest) = 0;
+
+  TransportSpace() : velocity{1} {}
+  TransportSpace(double velocity) : velocity{velocity} {}
+  virtual ~TransportSpace() {}
+};
+
+} // namespace ridepy
+
+#endif // RIDEPY_TRANSPORTSPACE_H

--- a/ridepy/vehicle_state_cython/cvehicle_state.h
+++ b/ridepy/vehicle_state_cython/cvehicle_state.h
@@ -15,7 +15,8 @@
 #include <utility>
 
 using namespace std;
-namespace cstuff {
+
+namespace ridepy {
 
 struct StopEventSpec {
   StopAction action;
@@ -158,6 +159,7 @@ public:
 
   void select_new_stoplist() { stoplist = stoplist_new; }
 };
-} // namespace cstuff
+
+} // namespace ridepy
 
 #endif // RIDEPY_CVEHICLE_STATE_H

--- a/ridepy/vehicle_state_cython/cvehicle_state.pxd
+++ b/ridepy/vehicle_state_cython/cvehicle_state.pxd
@@ -9,7 +9,7 @@ from ridepy.data_structures_cython.cdata_structures cimport (
 from ridepy.data_structures_cython.data_structures cimport StopAction
 from ridepy.util.spaces_cython.cspaces cimport TransportSpace
 
-cdef extern from "cvehicle_state.h" namespace 'cstuff':
+cdef extern from "cvehicle_state.h" namespace 'ridepy':
     cdef cppclass StopEventSpec:
         StopAction action
         int request_id

--- a/test/cpp_integration_test.cxx
+++ b/test/cpp_integration_test.cxx
@@ -3,7 +3,7 @@
 #include "gtest/gtest.h"
 
 using namespace std;
-using namespace cstuff;
+using namespace ridepy;
 
 double inf = 100000000;
 


### PR DESCRIPTION
As discussed with @debsankha , I started including RidePy to our "Ride-Pooling vs. Line Service" project. To make RidePy usable from there, I set up a new subdirectory `ridepy/cpp`, where I placed a CMakeLists.txt and some .h files that packs all the C++ files (except for `boost_graph_space` to avoid LRU dependency) from RidePy into a libRidePy.a, that can be linked to external C++ projects and RidePy classes can from there be included via 
```cpp
#include "ridepy/<classname>.h
```

RidePy now can be used by simply adding an 
```cmake
add_subdirectory(${RIDEPY_PATH}/ridepy/cpp)
```
to one's custom C++ project and then link the `RidePy` library where needed (assuming `RIDEPY_PATH` stores the path to RidePy's root directory).

If I see it correctly, it remains to implement the FleetState stuff in C++ to make RidePy fully usable in C++. That would then be subject to the next MR.

Outside the newly added `ridepy/cpp` dictionary, I did the following changes:
- renaming the namespace `cstuff` into `ridepy` to make code that includes RidePy stuff more understandable
- extracting the interface 'TransportSpace` into a separate .h to separate the abstract interface and the actual implementations of spaces
- removing the apparently unused include `../util/spaces_cython/cspaces.h` from `cdata_structures.h`
- added some Doxygen compatible (Qt style) doc comments, so that RidePy classes are properly explained in our documentation