### PR TITLE
Fast grid

### DIFF
--- a/ridepy/util/spaces_cython/__init__.py
+++ b/ridepy/util/spaces_cython/__init__.py
@@ -1,1 +1,1 @@
-from .spaces import Euclidean2D, Manhattan2D, Graph, TransportSpace
+from .spaces import Euclidean2D, Manhattan2D, Graph, TransportSpace, Grid

--- a/ridepy/util/spaces_cython/boost_graph_space.h
+++ b/ridepy/util/spaces_cython/boost_graph_space.h
@@ -108,8 +108,9 @@ public:
 
   GraphSpace(double velocity, vector<vertex_t> vertex_vec,
              vector<Edge> edge_vec, vector<double> weight_vec)
-      : TransportSpace<vertex_t>(), velocity(velocity), _g{vertex_vec.size()},
-        vertex2label{get(vertex_name, _g)},
+      : TransportSpace<vertex_t>(),
+        velocity(velocity), _g{vertex_vec.size()}, vertex2label{get(vertex_name,
+                                                                    _g)},
         _distances(static_cast<int>(vertex_vec.size())),
         _predecessors(static_cast<int>(vertex_vec.size())),
         _weights{weight_vec}, edge2weight{get(edge_weight, _g)} {

--- a/ridepy/util/spaces_cython/cspaces.cxx
+++ b/ridepy/util/spaces_cython/cspaces.cxx
@@ -67,6 +67,8 @@ double Grid::t(R2loc u, R2loc v) { return this->d(u, v) / this->velocity; }
 pair<R2loc, double> Grid::interp_dist(R2loc u, R2loc v, double dist_to_dest) {
   double frac = dist_to_dest / this->d(u, v);
 
+  // This is not the only way of doing it, but it is an easy way.
+
   double x_prec = u.first * frac + (1 - frac) * v.first;
   double y_prec = u.second * frac + (1 - frac) * v.second;
 

--- a/ridepy/util/spaces_cython/cspaces.cxx
+++ b/ridepy/util/spaces_cython/cspaces.cxx
@@ -66,7 +66,8 @@ double Grid::t(R2loc u, R2loc v) { return this->d(u, v) / this->velocity; }
 
 pair<R2loc, double> Grid::interp_dist(R2loc u, R2loc v, double dist_to_dest) {
 
-  if (u == v) return make_pair(u, 0);
+  if (u == v)
+    return make_pair(u, 0);
 
   double frac = dist_to_dest / this->d(u, v);
 

--- a/ridepy/util/spaces_cython/cspaces.cxx
+++ b/ridepy/util/spaces_cython/cspaces.cxx
@@ -70,8 +70,8 @@ pair<R2loc, double> Grid::interp_dist(R2loc u, R2loc v, double dist_to_dest) {
   double x_prec = u.first * frac + (1 - frac) * v.first;
   double y_prec = u.second * frac + (1 - frac) * v.second;
 
-  int x = ceil(x_rec / dm);
-  int y = ceil(y_rec / dn);
+  int x = ceil(x_prec / dm);
+  int y = ceil(y_prec / dn);
 
   double jump_time = x_prec - x + y_prec - y;
 

--- a/ridepy/util/spaces_cython/cspaces.cxx
+++ b/ridepy/util/spaces_cython/cspaces.cxx
@@ -65,6 +65,9 @@ double Grid::d(R2loc u, R2loc v) {
 double Grid::t(R2loc u, R2loc v) { return this->d(u, v) / this->velocity; }
 
 pair<R2loc, double> Grid::interp_dist(R2loc u, R2loc v, double dist_to_dest) {
+
+  if (u == v) return make_pair(u, 0);
+
   double frac = dist_to_dest / this->d(u, v);
 
   // This is not the only way of doing it, but it is an easy way.

--- a/ridepy/util/spaces_cython/cspaces.cxx
+++ b/ridepy/util/spaces_cython/cspaces.cxx
@@ -55,4 +55,32 @@ pair<R2loc, double> Manhattan2D::interp_time(R2loc u, R2loc v,
   return this->interp_dist(u, v, dist_to_dest);
 }
 
+Grid::Grid(int n, int m, double dn, double dm, double velocity)
+    : TransportSpace(), n(n), m(m), dn(dn), dm(dm), velocity(velocity) {}
+
+double Grid::d(R2loc u, R2loc v) {
+  return std::abs(u.first - v.first) + std::abs(u.second - v.second);
+}
+
+double Grid::t(R2loc u, R2loc v) { return this->d(u, v) / this->velocity; }
+
+pair<R2loc, double> Grid::interp_dist(R2loc u, R2loc v, double dist_to_dest) {
+  double frac = dist_to_dest / this->d(u, v);
+
+  double x_prec = u.first * frac + (1 - frac) * v.first;
+  double y_prec = u.second * frac + (1 - frac) * v.second;
+
+  int x = ceil(x_rec / dm);
+  int y = ceil(y_rec / dn);
+
+  double jump_time = x_prec - x + y_prec - y;
+
+  return make_pair(R2loc{x, y}, jump_time);
+}
+
+pair<R2loc, double> Grid::interp_time(R2loc u, R2loc v, double time_to_dest) {
+  double dist_to_dest = time_to_dest * velocity;
+  return interp_dist(u, v, dist_to_dest);
+}
+
 } // namespace ridepy

--- a/ridepy/util/spaces_cython/cspaces.cxx
+++ b/ridepy/util/spaces_cython/cspaces.cxx
@@ -75,7 +75,7 @@ pair<R2loc, double> Grid::interp_dist(R2loc u, R2loc v, double dist_to_dest) {
   int x = ceil(x_prec / dm);
   int y = ceil(y_prec / dn);
 
-  double jump_time = x_prec - x + y_prec - y;
+  double jump_time = x - x_prec + y - y_prec;
 
   return make_pair(R2loc{x, y}, jump_time);
 }

--- a/ridepy/util/spaces_cython/cspaces.h
+++ b/ridepy/util/spaces_cython/cspaces.h
@@ -71,6 +71,26 @@ public:
 };
 
 /*!
+ * \brief The Euclidean2D class allows vehicles to drive anywhere on the 2D
+ * plane.
+ */
+class Grid : public TransportSpace<R2loc> {
+public:
+  Grid(int n = 100, int m = 100, double dn = 1., double dm = 1.,
+       double velocity = 1.);
+
+  double d(R2loc u, R2loc v) override;
+  double t(R2loc u, R2loc v) override;
+  pair<R2loc, double> interp_dist(R2loc u, R2loc v,
+                                  double dist_to_dest) override;
+  pair<R2loc, double> interp_time(R2loc u, R2loc v,
+                                  double time_to_dest) override;
+
+  int n, m;
+  double dn, dm, velocity;
+};
+
+/*!
  * @}
  */
 

--- a/ridepy/util/spaces_cython/cspaces.pxd
+++ b/ridepy/util/spaces_cython/cspaces.pxd
@@ -39,6 +39,11 @@ cdef extern from "cspaces.h" namespace 'ridepy':
         Manhattan2D()
         Manhattan2D(double)
 
+    cdef cppclass Grid(TransportSpace[R2loc]):
+        int n, m
+        double dn,dm, velocity
+        Grid()
+        Grid(n, m, dn, dm, double)
 
 cdef extern from "boost_graph_space.h" namespace 'ridepy':
     cdef cppclass GraphSpace[Loc](TransportSpace[Loc]):

--- a/ridepy/util/spaces_cython/cspaces.pxd
+++ b/ridepy/util/spaces_cython/cspaces.pxd
@@ -43,7 +43,7 @@ cdef extern from "cspaces.h" namespace 'ridepy':
         int n, m
         double dn,dm, velocity
         Grid()
-        Grid(n, m, dn, dm, double)
+        Grid(int n, int m, double dn, double dm, double velocity)
 
 cdef extern from "boost_graph_space.h" namespace 'ridepy':
     cdef cppclass GraphSpace[Loc](TransportSpace[Loc]):

--- a/ridepy/util/spaces_cython/spaces.pxd
+++ b/ridepy/util/spaces_cython/spaces.pxd
@@ -7,7 +7,8 @@ from .cspaces cimport (
     Euclidean2D as CEuclidean2D,
     TransportSpace as CTransportSpace,
     Manhattan2D as CManhattan2D,
-    GraphSpace as CGraphSpace
+    GraphSpace as CGraphSpace,
+    Grid as CGrid
 )
 
 from ridepy.data_structures_cython.data_structures cimport LocType, R2loc
@@ -37,5 +38,5 @@ cdef class Manhattan2D(TransportSpace):
 cdef class Graph(TransportSpace):
     cdef CGraphSpace[int] *derived_ptr
 
-cdef class Grid(Graph):
-    ...
+cdef class Grid(TransportSpace):
+    cdef CGrid *derived_ptr

--- a/ridepy/util/spaces_cython/spaces.pxd
+++ b/ridepy/util/spaces_cython/spaces.pxd
@@ -41,4 +41,9 @@ cdef class Graph(TransportSpace):
 
 cdef class Grid(TransportSpace):
     cdef CGrid *derived_ptr
+    cdef readonly int n, m
+    cdef readonly double dn, dm, _velocity
+    cdef readonly vector[pair[float, float]] _vertices
+    cdef readonly vector[pair[pair[float, float], pair[float, float]]] _edges
+    cdef readonly vector[float] _weights
 

--- a/ridepy/util/spaces_cython/spaces.pxd
+++ b/ridepy/util/spaces_cython/spaces.pxd
@@ -36,3 +36,6 @@ cdef class Manhattan2D(TransportSpace):
 
 cdef class Graph(TransportSpace):
     cdef CGraphSpace[int] *derived_ptr
+
+cdef class Grid(Graph):
+    ...

--- a/ridepy/util/spaces_cython/spaces.pxd
+++ b/ridepy/util/spaces_cython/spaces.pxd
@@ -38,5 +38,7 @@ cdef class Manhattan2D(TransportSpace):
 cdef class Graph(TransportSpace):
     cdef CGraphSpace[int] *derived_ptr
 
+
 cdef class Grid(TransportSpace):
     cdef CGrid *derived_ptr
+

--- a/ridepy/util/spaces_cython/spaces.pyx
+++ b/ridepy/util/spaces_cython/spaces.pyx
@@ -15,7 +15,8 @@ from .cspaces cimport(
     R2loc,
     Euclidean2D as CEuclidean2D,
     Manhattan2D as CManhattan2D,
-    GraphSpace as CGraphSpace
+    GraphSpace as CGraphSpace,
+    Grid as CGrid
 )
 
 from typing import List, Tuple, Optional
@@ -318,7 +319,7 @@ cdef class Graph(TransportSpace):
         )
 
 
-cdef class Grid(Graph):
+cdef class Grid(TransportSpace):
     """
     Undirected square lattice
     """

--- a/ridepy/util/spaces_cython/spaces.pyx
+++ b/ridepy/util/spaces_cython/spaces.pyx
@@ -324,11 +324,11 @@ cdef class Grid(TransportSpace):
     Undirected square lattice
     """
 
-    def __cinit__(self, n, m, dn=1, dm=1, velocity=1):
+    def __cinit__(self, n=100, m=100, dn=1, dm=1, velocity=1):
         self.loc_type = LocType.R2LOC
         self.derived_ptr = self.u_space.space_r2loc_ptr = new CGrid(n, m, dn, dm, velocity)
 
-    def __init__(self, n, m, dn=1, dm=1, velocity=1):
+    def __init__(self, n=100, m=100, dn=1, dm=1, velocity=1):
         """
         Parameters
         ----------

--- a/ridepy/util/spaces_cython/spaces.pyx
+++ b/ridepy/util/spaces_cython/spaces.pyx
@@ -344,23 +344,26 @@ cdef class Grid(TransportSpace):
         self.n = n
         self.m = m
         self.dn = dn
-        self.dm= dm
+        self.dm = dm
+        self._velocity = velocity
 
-        self._vertices = np.c_[
+        vertices = np.c_[
             np.repeat(np.linspace(0, (n - 1) * dn, n), m),
             np.tile(np.linspace(0, (m - 1) * dm, m), n),
         ]
-
         edges = []
-        rows = self._vertices.reshape(-1, m, 2)
+        rows = vertices.reshape(-1, m, 2)
         for row in rows:
             edges += [(tuple(v1), tuple(v2)) for v1, v2 in zip(row, row[1:])]
 
         for r1, r2 in zip(rows, rows[1:]):
             edges += [(tuple(v1), tuple(v2)) for v1, v2 in zip(r1, r2)]
-        self._edges = np.array(edges)
+        edges = np.array(edges)
+        weights = np.ones(edges.shape[0])
 
-        self._weights = np.ones(self._edges.shape[0])
+        self._weights = weights
+        self._edges = edges
+        self._vertices = vertices
 
     def __dealloc__(self):
         del self.derived_ptr
@@ -373,7 +376,7 @@ cdef class Grid(TransportSpace):
 
     @property
     def velocity(self):
-        return self.velocity
+        return self._velocity
 
     def random_point(self):
         return random.choice(self.vertices)

--- a/test/test_space.py
+++ b/test/test_space.py
@@ -23,6 +23,7 @@ from ridepy.util.spaces_cython import (
     Euclidean2D as CyEuclidean2D,
     Manhattan2D as CyManhattan2D,
     Graph as CyGraph,
+    Grid as CyGrid,
 )
 
 from ridepy.extras.spaces import (
@@ -81,7 +82,7 @@ def test_Euclidean2D_smart_vectorize():
 
 
 # @pytest.mark.skip
-def test_grid():
+def test_graph_grid():
     space = Graph.from_nx(make_nx_grid())
 
     assert space.d(0, 0) == 0
@@ -102,6 +103,32 @@ def test_grid():
         assert np.isclose(jump_time_interp, jump_time)
 
     assert space.interp_dist(0, 0, 0) == (0, 0)
+
+
+def test_pure_grid():
+    space = CyGrid(3, 3)
+
+    assert space.d([0, 0], [0, 0]) == 0
+    assert space.d([0, 0], [0, 1]) == 1
+    assert space.d([0, 1], [0, 2]) == 1
+    assert space.d([0, 0], [0, 2]) == 2
+    assert space.d([0, 0], [1, 2]) == 3
+    assert space.d([0, 0], [1, 3]) == 4
+
+    # with pytest.raises(KeyError):
+    #     assert space.d([-1, 0], [0, 8]) == 4
+
+    for dist_to_dest, (next_node, jump_time) in zip(
+        [2, 1.1, 1, 0.1, 0],
+        [([0, 0], 0), ([0, 1], 0.1), ([0, 1], 0), ([0, 2], 0.1), ([0, 2], 0)],
+    ):
+        next_node_interp, jump_time_interp = space.interp_dist(
+            [0, 0], [0, 2], dist_to_dest
+        )
+        assert next_node_interp == tuple(next_node)
+        assert np.isclose(jump_time_interp, jump_time)
+
+    assert space.interp_dist((0, 0), (0, 0), 0) == ((0, 0), 0)
 
 
 def test_cyclic_graph():


### PR DESCRIPTION
This is an attempt to implement a significantly faster square grid transport space, compared to `Graph()`.
As of 220602, the interpolation is "stupid" and should be changed to:
- in each step, switch between traversing in x and y direction
- if in one direction distance remains, find a random place to introduce that into the path
- random here means, reproducible for any given pair of `(u, v)`, i.e. seeded by u, v.