### PR TITLE
Control for transients in the analytics module

### DIFF
--- a/src/ridepy/util/analytics/__init__.py
+++ b/src/ridepy/util/analytics/__init__.py
@@ -3,4 +3,7 @@ from ridepy.util.analytics.events import (
     get_stops_and_requests_from_events_dataframe,
 )
 from ridepy.util.analytics.vehicle import get_vehicle_quantities
-from ridepy.util.analytics.system import get_system_quantities
+from ridepy.util.analytics.system import (
+    get_system_quantities,
+    compute_transient_controlled_system_quantities,
+)

--- a/src/ridepy/util/analytics/system.py
+++ b/src/ridepy/util/analytics/system.py
@@ -5,8 +5,6 @@ import pandas as pd
 
 from typing import Optional, Any, Union
 
-from notebooks.full_simulation_overview import avg_stoplist_length
-
 
 def get_system_quantities(
     stops: pd.DataFrame,

--- a/src/ridepy/util/spaces_cython/boost_graph_space.h
+++ b/src/ridepy/util/spaces_cython/boost_graph_space.h
@@ -109,13 +109,11 @@ public:
   GraphSpace(double velocity, vector<vertex_t> vertex_vec,
              vector<Edge> edge_vec, vector<double> weight_vec)
       : TransportSpace<vertex_t>(),
-        velocity(velocity),
-        _g{vertex_vec.size()},
-        vertex2label{get(vertex_name, _g)},
+        velocity(velocity), _g{vertex_vec.size()}, vertex2label{get(vertex_name,
+                                                                    _g)},
         _distances(static_cast<int>(vertex_vec.size())),
         _predecessors(static_cast<int>(vertex_vec.size())),
-        _weights{weight_vec},
-        edge2weight{get(edge_weight, _g)} {
+        _weights{weight_vec}, edge2weight{get(edge_weight, _g)} {
     // this->vertex2label = get(vertex_name, this->_g);
     // add vertex properties
     int idx = 0;

--- a/src/ridepy/util/spaces_cython/cspaces.cxx
+++ b/src/ridepy/util/spaces_cython/cspaces.cxx
@@ -30,11 +30,82 @@ pair<R2loc, double> Euclidean2D::interp_time(R2loc u, R2loc v,
   return this->interp_dist(u, v, dist_to_dest);
 }
 
+Euclidean2DPeriodicBoundaries::Euclidean2DPeriodicBoundaries(double velocity)
+    : Euclidean2D(), velocity(velocity) {}
+
+double Euclidean2DPeriodicBoundaries::d(R2loc u, R2loc v) {
+
+  // stolen from <https://blog.demofox.org/2017/10/01/calculating-the-distance-
+  //                 between-points-in-wrap-around-toroidal-space/>
+  double dx = abs(v.first - u.first);
+  double dy = abs(v.second - u.second);
+
+  if (dx > 0.5)
+    dx = 1.0 - dx;
+  if (dy > 0.5)
+    dy = 1.0 - dy;
+
+  return sqrt(dx * dx + dy * dy);
+}
+
+double Euclidean2DPeriodicBoundaries::t(R2loc u, R2loc v) {
+  return this->d(u, v) / this->velocity;
+}
+
+pair<R2loc, double>
+Euclidean2DPeriodicBoundaries::interp_dist(R2loc u, R2loc v,
+                                           double dist_to_dest) {
+
+  double x1 = u.first;
+  double y1 = u.second;
+
+  double x2 = v.first;
+  double y2 = v.second;
+
+  double dx = v.first - u.first;
+  double dy = v.second - u.second;
+
+  if (dx > 0.5) {
+    // Wrapping around in positive x direction
+    dx = 1.0 - dx;
+    x2 = x2 + 1.0;
+  } else if (dx < -0.5) {
+    // Wrapping around in negative x direction
+    dx = 1.0 + dx;
+    x2 = x2 - 1.0;
+  }
+
+  if (abs(dy) > 0.5) {
+    // Wrapping around in positive y direction
+    dy = 1.0 - dy;
+    y2 = y2 + 1.0;
+  } else if (dy < -0.5) {
+    // Wrapping around in negative y direction
+    dy = 1.0 + dy;
+    y2 = y2 - 1.0;
+  }
+
+  double dist = sqrt(dx * dx + dy * dy);
+  double frac = dist_to_dest / dist;
+
+  double x_r = fmod(x1 * frac + (1 - frac) * x2, 1.0);
+  double y_r = fmod(y1 * frac + (1 - frac) * y2, 1.0);
+
+  return make_pair(R2loc{x_r, y_r}, 0);
+}
+
+pair<R2loc, double>
+Euclidean2DPeriodicBoundaries::interp_time(R2loc u, R2loc v,
+                                           double time_to_dest) {
+  double dist_to_dest = time_to_dest * (this->velocity);
+  return this->interp_dist(u, v, dist_to_dest);
+}
+
 Manhattan2D::Manhattan2D(double velocity)
     : TransportSpace(), velocity(velocity) {}
 
 double Manhattan2D::d(R2loc u, R2loc v) {
-  return std::abs(u.first - v.first) + std::abs(u.second - v.second);
+  return abs(u.first - v.first) + abs(u.second - v.second);
 }
 
 double Manhattan2D::t(R2loc u, R2loc v) {
@@ -44,6 +115,7 @@ double Manhattan2D::t(R2loc u, R2loc v) {
 pair<R2loc, double> Manhattan2D::interp_dist(R2loc u, R2loc v,
                                              double dist_to_dest) {
   double frac = dist_to_dest / this->d(u, v);
+
   return make_pair(R2loc{u.first * frac + (1 - frac) * v.first,
                          u.second * frac + (1 - frac) * v.second},
                    0);

--- a/src/ridepy/util/spaces_cython/cspaces.h
+++ b/src/ridepy/util/spaces_cython/cspaces.h
@@ -48,6 +48,20 @@ public:
   double velocity;
 };
 
+class Euclidean2DPeriodicBoundaries : public Euclidean2D {
+public:
+  Euclidean2DPeriodicBoundaries(double velocity = 1.);
+
+  double d(R2loc u, R2loc v) override;
+  double t(R2loc u, R2loc v) override;
+  pair<R2loc, double> interp_dist(R2loc u, R2loc v,
+                                  double dist_to_dest) override;
+  pair<R2loc, double> interp_time(R2loc u, R2loc v,
+                                  double time_to_dest) override;
+
+  double velocity;
+};
+
 /*!
  * \brief The Euclidean2D class allows vehicles to drive anywhere on the 2D
  * plane.

--- a/src/ridepy/util/spaces_cython/cspaces.pxd
+++ b/src/ridepy/util/spaces_cython/cspaces.pxd
@@ -37,6 +37,11 @@ cdef extern from "cspaces.h" namespace 'ridepy':
         Euclidean2D()
         Euclidean2D(double)
 
+    cdef cppclass Euclidean2DPeriodicBoundaries(Euclidean2D):
+        double velocity
+        Euclidean2DPeriodicBoundaries()
+        Euclidean2DPeriodicBoundaries(double)
+
     cdef cppclass Manhattan2D(TransportSpace[R2loc]):
         double velocity
         Manhattan2D()

--- a/src/ridepy/util/spaces_cython/spaces.pyx
+++ b/src/ridepy/util/spaces_cython/spaces.pyx
@@ -15,6 +15,7 @@ from .cspaces cimport(
     R2loc,
     uiloc,
     Euclidean2D as CEuclidean2D,
+    Euclidean2DPeriodicBoundaries as CEuclidean2DPeriodicBoundaries,
     Manhattan2D as CManhattan2D,
     GraphSpace as CGraphSpace
 )
@@ -106,9 +107,12 @@ cdef class Euclidean2D(TransportSpace):
     """
     :math:`\mathbb{R}^2` with :math:`L_2`-induced metric (Euclidean).
     """
-    def __cinit__(self, double velocity=1, *args, **kwargs):
+    def __cinit__(self, double velocity=1, periodic_boundaries=False, *args, **kwargs):
         self.loc_type = LocType.R2LOC
-        self.derived_ptr = self.u_space.space_r2loc_ptr = new CEuclidean2D(velocity)
+        if periodic_boundaries:
+            self.derived_ptr = self.u_space.space_r2loc_ptr = new CEuclidean2DPeriodicBoundaries(velocity)
+        else:
+            self.derived_ptr = self.u_space.space_r2loc_ptr = new CEuclidean2D(velocity)
 
     def __init__(self, *args, **kwargs): # remember both __cinit__ and __init__ gets the same arguments passed
         """


### PR DESCRIPTION
- Added the option for the `Euclidean2D` space to have periodic boundaries
- Added analytics function `compute_transient_controlled_system_quantities`
- Commented the C++ dispatcher a bit better

**WARNING**

This PR currently introduces a new bug. I don't understand the actual reason yet, but all `<sim_id>_params.json` files have `velocity: 1` for their `space`. This must somehow be a consequence of having added the boundary condition kwargs, probably the serialization is broken.

Although this produces the correct output:

```python
from ridepy.extras.io import ParamsJSONEncoder
import json

print(json.dumps({'space': space}, indent=4, cls=ParamsJSONEncoder))
```